### PR TITLE
[Bug #156264852] Fix error in the query parameter for endpoint url.

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -47,7 +47,7 @@ class BookAPITests(unittest.TestCase):
         ''' test the api can retrieve books
         '''
         item_id = 1
-        resp = self.app.get(self.BASE_URL + '%d' % item_id)
+        resp = self.app.get(self.BASE_URL + '%d/' % item_id)
         self.assertEqual(resp.status_code, 200,
                          msg='Should retrieve data from the api.')
 


### PR DESCRIPTION
Add trailing slash to variable query parameter for retrieving a single item.